### PR TITLE
fix a bug about pflush initialization

### DIFF
--- a/src/lib/init.c
+++ b/src/lib/init.c
@@ -143,7 +143,7 @@ void init()
         }
 #endif
         int write_latency;
-        __cconfig_lookup_bool(&cfg, "latency.write", &write_latency);
+        __cconfig_lookup_int(&cfg, "latency.write", &write_latency);
         init_pflush(cpu_speed_mhz(), write_latency);
     }
 

--- a/src/lib/pflush.c
+++ b/src/lib/pflush.c
@@ -120,5 +120,9 @@ pflush(uint64_t *addr)
     start = asm_rdtscp();
     asm_clflush(addr);  
     stop = asm_rdtscp();
-    emulate_latency_ns(global_write_latency_ns - cycles_to_ns(global_cpu_speed_mhz, stop-start));
+    int to_insert_ns = global_write_latency_ns - cycles_to_ns(global_cpu_speed_mhz, stop-start);
+    if (to_insert_ns <= 0) {
+        return;
+    }
+    emulate_latency_ns(to_insert_ns);
 }


### PR DESCRIPTION
The `write_latency` parsed for pflush from nvmemul.ini should be a `int` rather than a `bool`. 
And in my testing, the delay to insert in pflush sometimes may small than 0, which will cause a infinite loop.
After fixing the bug, quartz now can emulate the clflush latency correctly.