### PR TITLE
Handling the case where the rdpmc's value exceeds the max value.

### DIFF
--- a/src/lib/cpu/pmc.c
+++ b/src/lib/cpu/pmc.c
@@ -20,6 +20,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 #pragma GCC push_options
 #pragma GCC optimize ("O0")
+
+// The width of general purpose counters are 40bits.
+// https://www.felixcloutier.com/x86/RDPMC.html
+#define RDPMC_MAX_VALUE 0xFFFFFFFFFF  
+
 long long rdpmc(int counter) 
 {
 
@@ -192,8 +197,10 @@ uint64_t read_pmc_hw_event_diff(pmc_hw_event_t* event)
     int cpu_id = thread_self()->cpu_id;
     uint64_t cur_val = read_pmc_hw_event_cur(event);
     uint64_t last_val = event->last_val[cpu_id];
+    //if (cur_val < last_val && (event->hw_cntr_id == 0)) {
     if (cur_val < last_val) {
-        return 0;
+        event->last_val[cpu_id] = cur_val;
+        return (cur_val + (RDPMC_MAX_VALUE - last_val));
     }
     event->last_val[cpu_id] = cur_val;
     return cur_val - last_val;


### PR DESCRIPTION
 This part causes **the stall cycle to always be zero** after the counter value exceeds the max value and then increases from 0 in the current code.

Existing code returns 0 without updating previously read counter value when the previously read counter value is larger than the currently read counter value. This case occurs only the counter value exceeds the max value and then starts from 0 again.

**This issue can make the stall cycle always zero after the counter value exceeds the max value and may not add NVM latency.**

Suppose the Max value of the counter is 100.
After computation,
Last read counter value is 100.
Current read counter value is 3.
Return value is 0.

and then next read results are 
Last read counter value is 100.
Current read counter value is 20
Return value is 0.
... (repeat)

Since the last read value is not updated, the result will always return 0 in the current code and **NVM latency will not be injected because stall cycle is 0.**

So I did an exception handling if the last read value was greater than current counter value, considering that the width of general purpose counter is 40bits.
