### PR TITLE
fix the compling problems of copy_from_user() and copy_to_user() in s…

### DIFF
--- a/src/dev/pmc.c
+++ b/src/dev/pmc.c
@@ -24,8 +24,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #include <linux/proc_fs.h>
 #include <linux/fcntl.h>
 #include <linux/smp.h>
+#include <linux/uaccess.h>
+
 #include <asm/msr.h>
 #include <asm/uaccess.h>
+
 #include "ioctl_query.h"
 
 static long pmc_ioctl(struct file *f, unsigned int cmd, unsigned long arg);


### PR DESCRIPTION
src/dev/pmc.c

The building will fail, the errors are copy_from_user() and copy_to_user() not well defined, because the src/dev/pmc.c doesn't include "linux/uaccess.h"
